### PR TITLE
Api url patch

### DIFF
--- a/src/api/providers/fetchers/syntx.ts
+++ b/src/api/providers/fetchers/syntx.ts
@@ -4,7 +4,7 @@ import type { ModelInfo } from "@roo-code/types"
 
 export async function getSyntxModels(
 	apiKey: string,
-	baseUrl: string = "https://api.syntx.dev ",
+	baseUrl: string = "https://api.syntx.dev",
 ): Promise<Record<string, ModelInfo>> {
 	const models: Record<string, ModelInfo> = {}
 

--- a/src/api/providers/fetchers/syntx.ts
+++ b/src/api/providers/fetchers/syntx.ts
@@ -4,7 +4,7 @@ import type { ModelInfo } from "@roo-code/types"
 
 export async function getSyntxModels(
 	apiKey: string,
-	baseUrl: string = "https://lagrange-inference-server-production.up.railway.app",
+	baseUrl: string = "https://api.syntx.dev ",
 ): Promise<Record<string, ModelInfo>> {
 	const models: Record<string, ModelInfo> = {}
 

--- a/src/api/providers/syntx.ts
+++ b/src/api/providers/syntx.ts
@@ -56,7 +56,7 @@ export class SyntxHandler extends BaseProvider implements SingleCompletionHandle
 	}
 
 	private getBaseURL(): string {
-		const baseUrl = this.options.syntxBaseUrl || "https://api.syntx.dev "
+		const baseUrl = this.options.syntxBaseUrl || "https://api.syntx.dev"
 		return baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl
 	}
 

--- a/src/api/providers/syntx.ts
+++ b/src/api/providers/syntx.ts
@@ -56,7 +56,7 @@ export class SyntxHandler extends BaseProvider implements SingleCompletionHandle
 	}
 
 	private getBaseURL(): string {
-		const baseUrl = this.options.syntxBaseUrl || "https://lagrange-inference-server-production.up.railway.app"
+		const baseUrl = this.options.syntxBaseUrl || "https://api.syntx.dev "
 		return baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl
 	}
 

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -560,7 +560,7 @@ export const webviewMessageHandler = async (
 						apiKey: apiConfiguration.syntxApiKey || "",
 						baseUrl:
 							apiConfiguration.syntxBaseUrl ||
-							"https://api.syntx.dev ",
+							"https://api.syntx.dev",
 					},
 				},
 			]

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -560,7 +560,7 @@ export const webviewMessageHandler = async (
 						apiKey: apiConfiguration.syntxApiKey || "",
 						baseUrl:
 							apiConfiguration.syntxBaseUrl ||
-							"https://lagrange-inference-server-production.up.railway.app",
+							"https://api.syntx.dev ",
 					},
 				},
 			]


### PR DESCRIPTION
Merging updated URL endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Updated the default Syntx service endpoint to api.syntx.dev, improving reliability and reducing connection failures when no custom URL is configured. No action needed for most users.

* Chores
  * Aligned the default Syntx base URL across the app to consistently use the new domain, ensuring uniform behavior in settings and message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->