### PR TITLE
added translation for vsix package

### DIFF
--- a/src/package.nls.ca.json
+++ b/src/package.nls.ca.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "Enfocar Camp d'Entrada",
 	"command.setCustomStoragePath.title": "Establir Ruta d'Emmagatzematge Personalitzada",
 	"command.importSettings.title": "Importar Configuració",
+	"command.importTask.title": "Importa tasca",
 	"command.terminal.addToContext.title": "Afegir Contingut del Terminal al Context",
 	"command.terminal.fixCommand.title": "Corregir Aquesta Ordre",
 	"command.terminal.explainCommand.title": "Explicar Aquesta Ordre",

--- a/src/package.nls.de.json
+++ b/src/package.nls.de.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "Eingabefeld Fokussieren",
 	"command.setCustomStoragePath.title": "Benutzerdefinierten Speicherpfad Festlegen",
 	"command.importSettings.title": "Einstellungen Importieren",
+	"command.importTask.title": "Aufgabe importieren",
 	"command.terminal.addToContext.title": "Terminal-Inhalt zum Kontext Hinzufügen",
 	"command.terminal.fixCommand.title": "Diesen Befehl Reparieren",
 	"command.terminal.explainCommand.title": "Diesen Befehl Erklären",

--- a/src/package.nls.es.json
+++ b/src/package.nls.es.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "Enfocar Campo de Entrada",
 	"command.setCustomStoragePath.title": "Establecer Ruta de Almacenamiento Personalizada",
 	"command.importSettings.title": "Importar Configuración",
+	"command.importTask.title": "Importar tarea",
 	"command.terminal.addToContext.title": "Añadir Contenido de Terminal al Contexto",
 	"command.terminal.fixCommand.title": "Corregir Este Comando",
 	"command.terminal.explainCommand.title": "Explicar Este Comando",

--- a/src/package.nls.fr.json
+++ b/src/package.nls.fr.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "Focus sur le Champ de Saisie",
 	"command.setCustomStoragePath.title": "Définir le Chemin de Stockage Personnalisé",
 	"command.importSettings.title": "Importer les Paramètres",
+	"command.importTask.title": "Importer la tâche",
 	"command.terminal.addToContext.title": "Ajouter le Contenu du Terminal au Contexte",
 	"command.terminal.fixCommand.title": "Corriger cette Commande",
 	"command.terminal.explainCommand.title": "Expliquer cette Commande",

--- a/src/package.nls.hi.json
+++ b/src/package.nls.hi.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "इनपुट फ़ील्ड पर फोकस करें",
 	"command.setCustomStoragePath.title": "कस्टम स्टोरेज पाथ सेट करें",
 	"command.importSettings.title": "सेटिंग्स इम्पोर्ट करें",
+	"command.importTask.title": "कार्य आयात करें",
 	"command.terminal.addToContext.title": "टर्मिनल सामग्री को संदर्भ में जोड़ें",
 	"command.terminal.fixCommand.title": "यह कमांड ठीक करें",
 	"command.terminal.explainCommand.title": "यह कमांड समझाएं",

--- a/src/package.nls.id.json
+++ b/src/package.nls.id.json
@@ -22,6 +22,7 @@
 	"command.focusInput.title": "Fokus ke Field Input",
 	"command.setCustomStoragePath.title": "Atur Path Penyimpanan Kustom",
 	"command.importSettings.title": "Impor Pengaturan",
+	"command.importTask.title": "Impor Tugas",
 	"command.terminal.addToContext.title": "Tambahkan Konten Terminal ke Konteks",
 	"command.terminal.fixCommand.title": "Perbaiki Perintah Ini",
 	"command.terminal.explainCommand.title": "Jelaskan Perintah Ini",

--- a/src/package.nls.it.json
+++ b/src/package.nls.it.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "Focalizza Campo di Input",
 	"command.setCustomStoragePath.title": "Imposta Percorso di Archiviazione Personalizzato",
 	"command.importSettings.title": "Importa Impostazioni",
+	"command.importTask.title": "Importa attività",
 	"command.terminal.addToContext.title": "Aggiungi Contenuto del Terminale al Contesto",
 	"command.terminal.fixCommand.title": "Correggi Questo Comando",
 	"command.terminal.explainCommand.title": "Spiega Questo Comando",

--- a/src/package.nls.ja.json
+++ b/src/package.nls.ja.json
@@ -22,6 +22,7 @@
 	"command.focusInput.title": "入力フィールドにフォーカス",
 	"command.setCustomStoragePath.title": "カスタムストレージパスの設定",
 	"command.importSettings.title": "設定をインポート",
+	"command.importTask.title": "タスクをインポート",
 	"command.terminal.addToContext.title": "ターミナルの内容をコンテキストに追加",
 	"command.terminal.fixCommand.title": "このコマンドを修正",
 	"command.terminal.explainCommand.title": "このコマンドを説明",

--- a/src/package.nls.json
+++ b/src/package.nls.json
@@ -22,6 +22,7 @@
 	"command.focusInput.title": "Focus Input Field",
 	"command.setCustomStoragePath.title": "Set Custom Storage Path",
 	"command.importSettings.title": "Import Settings",
+	"command.importTask.title": "Import Task",
 	"command.terminal.addToContext.title": "Add Terminal Content to Context",
 	"command.terminal.fixCommand.title": "Fix This Command",
 	"command.terminal.explainCommand.title": "Explain This Command",

--- a/src/package.nls.ko.json
+++ b/src/package.nls.ko.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "입력 필드 포커스",
 	"command.setCustomStoragePath.title": "사용자 지정 저장소 경로 설정",
 	"command.importSettings.title": "설정 가져오기",
+	"command.importTask.title": "작업 가져오기",
 	"command.terminal.addToContext.title": "터미널 내용을 컨텍스트에 추가",
 	"command.terminal.fixCommand.title": "이 명령어 수정",
 	"command.terminal.explainCommand.title": "이 명령어 설명",

--- a/src/package.nls.nl.json
+++ b/src/package.nls.nl.json
@@ -22,6 +22,7 @@
 	"command.focusInput.title": "Focus op Invoerveld",
 	"command.setCustomStoragePath.title": "Aangepast Opslagpad Instellen",
 	"command.importSettings.title": "Instellingen Importeren",
+	"command.importTask.title": "Taak importeren",
 	"command.terminal.addToContext.title": "Terminalinhoud aan Context Toevoegen",
 	"command.terminal.fixCommand.title": "Repareer Dit Commando",
 	"command.terminal.explainCommand.title": "Leg Dit Commando Uit",

--- a/src/package.nls.pl.json
+++ b/src/package.nls.pl.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "Fokus na Pole Wprowadzania",
 	"command.setCustomStoragePath.title": "Ustaw Niestandardową Ścieżkę Przechowywania",
 	"command.importSettings.title": "Importuj Ustawienia",
+	"command.importTask.title": "Importuj zadanie",
 	"command.terminal.addToContext.title": "Dodaj Zawartość Terminala do Kontekstu",
 	"command.terminal.fixCommand.title": "Napraw tę Komendę",
 	"command.terminal.explainCommand.title": "Wyjaśnij tę Komendę",

--- a/src/package.nls.pt-BR.json
+++ b/src/package.nls.pt-BR.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "Focar Campo de Entrada",
 	"command.setCustomStoragePath.title": "Definir Caminho de Armazenamento Personalizado",
 	"command.importSettings.title": "Importar Configurações",
+	"command.importTask.title": "Importar tarefa",
 	"command.terminal.addToContext.title": "Adicionar Conteúdo do Terminal ao Contexto",
 	"command.terminal.fixCommand.title": "Corrigir Este Comando",
 	"command.terminal.explainCommand.title": "Explicar Este Comando",

--- a/src/package.nls.ru.json
+++ b/src/package.nls.ru.json
@@ -22,6 +22,7 @@
 	"command.focusInput.title": "Фокус на поле ввода",
 	"command.setCustomStoragePath.title": "Указать путь хранения",
 	"command.importSettings.title": "Импортировать настройки",
+	"command.importTask.title": "Импортировать задачу",
 	"command.terminal.addToContext.title": "Добавить содержимое терминала в контекст",
 	"command.terminal.fixCommand.title": "Исправить эту команду",
 	"command.terminal.explainCommand.title": "Объяснить эту команду",

--- a/src/package.nls.tr.json
+++ b/src/package.nls.tr.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "Giriş Alanına Odaklan",
 	"command.setCustomStoragePath.title": "Özel Depolama Yolunu Ayarla",
 	"command.importSettings.title": "Ayarları İçe Aktar",
+	"command.importTask.title": "Görevi içe aktar",
 	"command.terminal.addToContext.title": "Terminal İçeriğini Bağlama Ekle",
 	"command.terminal.fixCommand.title": "Bu Komutu Düzelt",
 	"command.terminal.explainCommand.title": "Bu Komutu Açıkla",

--- a/src/package.nls.vi.json
+++ b/src/package.nls.vi.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "Tập Trung vào Trường Nhập",
 	"command.setCustomStoragePath.title": "Đặt Đường Dẫn Lưu Trữ Tùy Chỉnh",
 	"command.importSettings.title": "Nhập Cài Đặt",
+	"command.importTask.title": "Nhập nhiệm vụ",
 	"command.terminal.addToContext.title": "Thêm Nội Dung Terminal vào Ngữ Cảnh",
 	"command.terminal.fixCommand.title": "Sửa Lệnh Này",
 	"command.terminal.explainCommand.title": "Giải Thích Lệnh Này",

--- a/src/package.nls.zh-CN.json
+++ b/src/package.nls.zh-CN.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "聚焦输入框",
 	"command.setCustomStoragePath.title": "设置自定义存储路径",
 	"command.importSettings.title": "导入设置",
+	"command.importTask.title": "导入任务",
 	"command.terminal.addToContext.title": "将终端内容添加到上下文",
 	"command.terminal.fixCommand.title": "修复此命令",
 	"command.terminal.explainCommand.title": "解释此命令",

--- a/src/package.nls.zh-TW.json
+++ b/src/package.nls.zh-TW.json
@@ -10,6 +10,7 @@
 	"command.focusInput.title": "聚焦輸入框",
 	"command.setCustomStoragePath.title": "設定自訂儲存路徑",
 	"command.importSettings.title": "匯入設定",
+	"command.importTask.title": "匯入任務",
 	"command.terminal.addToContext.title": "將終端內容新增到上下文",
 	"command.terminal.fixCommand.title": "修復此命令",
 	"command.terminal.explainCommand.title": "解釋此命令",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized label for the “Import Task” command across supported languages, improving international UX. Languages include: English, Catalan, German, Spanish, French, Hindi, Indonesian, Italian, Japanese, Korean, Dutch, Polish, Portuguese (Brazil), Russian, Turkish, Vietnamese, Chinese (Simplified), and Chinese (Traditional). Users will now see the proper translation for this command in their selected language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->