### PR TITLE
Newauth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # SyntX Changelog
 
+## [2.5.0] - 25-10-2025
+
+- Added provider configuration at the startup screen
+
 ## [2.4.3] - 29-08-2025
 
 - Updated the Chat UI

--- a/src/core/config/ProviderSettingsManager.ts
+++ b/src/core/config/ProviderSettingsManager.ts
@@ -44,7 +44,7 @@ export class ProviderSettingsManager {
 
 	private readonly defaultProviderProfiles: ProviderProfiles = {
 		currentApiConfigName: "default",
-		apiConfigs: { default: { id: this.defaultConfigId, apiProvider: "syntx" } },
+		apiConfigs: { default: { id: this.defaultConfigId, apiProvider: "anthropic" } },
 		modeApiConfigs: this.defaultModeApiConfigs,
 		migrations: {
 			rateLimitSecondsMigrated: true, // Mark as migrated on fresh installs

--- a/src/core/config/ProviderSettingsManager.ts
+++ b/src/core/config/ProviderSettingsManager.ts
@@ -44,7 +44,7 @@ export class ProviderSettingsManager {
 
 	private readonly defaultProviderProfiles: ProviderProfiles = {
 		currentApiConfigName: "default",
-		apiConfigs: { default: { id: this.defaultConfigId, apiProvider: "anthropic" } },
+		apiConfigs: { default: { id: this.defaultConfigId, apiProvider: "openrouter" } },
 		modeApiConfigs: this.defaultModeApiConfigs,
 		migrations: {
 			rateLimitSecondsMigrated: true, // Mark as migrated on fresh installs

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1964,11 +1964,11 @@ export class ClineProvider
 
 		vscode.window.showInformationMessage("Successfully authenticated with SyntX website")
 
-		// Ensure provider profile is set to anthropic after website login
+		// Ensure provider profile is set to openrouter after website login
 		const { apiConfiguration, currentApiConfigName } = await this.getState()
 		const newConfiguration = {
 			...apiConfiguration,
-			apiProvider: "anthropic" as const,
+			apiProvider: "openrouter" as const,
 			syntxApiKey: apiKey,
 		}
 		await this.upsertProviderProfile(currentApiConfigName, newConfiguration)

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1453,6 +1453,11 @@ export class ClineProvider
 		const currentMode = mode ?? defaultModeSlug
 		const hasSystemPromptOverride = await this.hasFileBasedSystemPromptOverride(currentMode)
 
+		// Get website authentication state
+		const websiteUsername = await this.contextProxy.getValue("websiteUsername")
+		const syntxApiKey = await this.contextProxy.getValue("syntxApiKey")
+		const websiteNotAuthenticated = !websiteUsername || !syntxApiKey
+
 		return {
 			version: this.context.extension?.packageJSON?.version ?? "",
 			apiConfiguration,
@@ -1562,6 +1567,10 @@ export class ClineProvider
 			alwaysAllowFollowupQuestions: alwaysAllowFollowupQuestions ?? false,
 			followupAutoApproveTimeoutMs: followupAutoApproveTimeoutMs ?? 60000,
 			diagnosticsEnabled: diagnosticsEnabled ?? true,
+			// Website authentication
+			websiteUsername,
+			syntxApiKey,
+			websiteNotAuthenticated,
 		}
 	}
 
@@ -1941,25 +1950,25 @@ export class ClineProvider
 
 		// Send authentication success message to webview
 		await this.postMessageToWebview({
-			type: "websiteAuth",
-			text: JSON.stringify({ authenticated: true, username, apiKey }),
+			type: "requestAnthropicApiKey",
+			text: JSON.stringify({ username }),
 		})
 
 		// Ensure we navigate to chat view after authentication, not settings
-		await this.postMessageToWebview({
-			type: "action",
-			action: "chatButtonClicked",
-		})
+		// await this.postMessageToWebview({
+		// 	type: "action",
+		// 	action: "chatButtonClicked",
+		// })
 
 		await this.postStateToWebview(true) // Skip MDM redirect during auth flow
 
 		vscode.window.showInformationMessage("Successfully authenticated with SyntX website")
 
-		// Ensure provider profile is set to syntx after website login
+		// Ensure provider profile is set to anthropic after website login
 		const { apiConfiguration, currentApiConfigName } = await this.getState()
 		const newConfiguration = {
 			...apiConfiguration,
-			apiProvider: "syntx" as const,
+			apiProvider: "anthropic" as const,
 			syntxApiKey: apiKey,
 		}
 		await this.upsertProviderProfile(currentApiConfigName, newConfiguration)

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -2353,5 +2353,43 @@ export const webviewMessageHandler = async (
 			}
 			break
 		}
+
+		case "anthropicApiKeySubmitted": {
+			try {
+				const payload = message.payload as { apiConfiguration?: any; username?: string } | undefined
+				if (!payload?.apiConfiguration) {
+					throw new Error("API configuration is required")
+				}
+
+				const { apiConfiguration: newApiConfiguration, username } = payload
+
+				// Update provider configuration with the complete configuration from the form
+				const { apiConfiguration: existingConfig, currentApiConfigName } = await provider.getState()
+				const mergedConfiguration = {
+					...existingConfig,
+					...newApiConfiguration,
+				}
+
+				await provider.upsertProviderProfile(currentApiConfigName, mergedConfiguration)
+
+				// Send success message first to clear the API key screen
+				await provider.postMessageToWebview({
+					type: "websiteAuth",
+					text: JSON.stringify({ authenticated: true, username }),
+				})
+
+				// Update the full state to reflect changes
+				await provider.postStateToWebview()
+
+				// Show demo window last so it doesn't interfere with state updates
+				await provider.openDemoWindow()
+
+				vscode.window.showInformationMessage("Anthropic API key saved successfully")
+			} catch (error) {
+				provider.log(`Failed to save Anthropic API key: ${error}`)
+				vscode.window.showErrorMessage("Failed to save API key")
+			}
+			break
+		}
 	}
 }

--- a/src/package.json
+++ b/src/package.json
@@ -3,7 +3,7 @@
 	"displayName": "%extension.displayName%",
 	"description": "%extension.description%",
 	"publisher": "OrangecatTechPvtLtd",
-	"version": "2.4.3",
+	"version": "2.5.0",
 	"icon": "assets/icons/icon.png",
 	"galleryBanner": {
 		"color": "#FFFFFF",

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -111,6 +111,7 @@ export interface ExtensionMessage {
 		| "websiteAuthCallback"
 		| "showDeleteMessageDialog"
 		| "showEditMessageDialog"
+		| "requestAnthropicApiKey"
 	text?: string
 	payload?: any // Add a generic payload for now, can refine later
 	agentId?: string
@@ -290,6 +291,7 @@ export type ExtensionState = Pick<
 	websiteUsername?: string
 	syntxApiKey?: string
 	websiteNotAuthenticated?: boolean
+	showAnthropicApiKeyScreen?: boolean
 
 	autoCondenseContext: boolean
 	autoCondenseContextPercent: number

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -203,6 +203,7 @@ export interface WebviewMessage {
 		| "checkRulesDirectoryResult"
 		| "saveCodeIndexSettingsAtomic"
 		| "requestCodeIndexSecretStatus"
+		| "anthropicApiKeySubmitted"
 	text?: string
 	editedMessageContent?: string
 	tab?: "settings" | "history" | "mcp" | "modes" | "chat" | "marketplace" | "account"
@@ -317,6 +318,11 @@ export type InstallMarketplaceItemWithParametersPayload = z.infer<
 	typeof installMarketplaceItemWithParametersPayloadSchema
 >
 
+export interface AnthropicApiKeySubmittedPayload {
+	apiConfiguration: any // Using any to match ProviderSettings from @roo-code/types
+	username?: string
+}
+
 export type WebViewMessagePayload =
 	| CheckpointDiffPayload
 	| CheckpointRestorePayload
@@ -324,3 +330,4 @@ export type WebViewMessagePayload =
 	| IndexClearedPayload
 	| InstallMarketplaceItemWithParametersPayload
 	| UpdateTodoListPayload
+	| AnthropicApiKeySubmittedPayload

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -15,6 +15,7 @@ import HistoryView from "./components/history/HistoryView"
 import SettingsView, { SettingsViewRef } from "./components/settings/SettingsView"
 import WelcomeView from "./components/welcome/WelcomeView"
 import GetStartedView from "./components/welcome/GetStartedView"
+import AnthropicApiKeyView from "./components/welcome/AnthropicApiKeyView"
 import McpView from "./components/mcp/McpView"
 import { MarketplaceView } from "./components/marketplace/MarketplaceView"
 import ModesView from "./components/modes/ModesView"
@@ -74,6 +75,8 @@ const App = () => {
 		renderContext,
 		mdmCompliant,
 		websiteNotAuthenticated,
+		showAnthropicApiKeyScreen,
+		websiteUsername,
 	} = useExtensionState()
 
 	// Create a persistent state manager
@@ -217,6 +220,13 @@ const App = () => {
 	// don't want to lose (user input, disableInput, askResponse promise, etc.)
 	return websiteNotAuthenticated ? (
 		<GetStartedView />
+	) : showAnthropicApiKeyScreen ? (
+		<AnthropicApiKeyView
+			username={websiteUsername}
+			onComplete={() => {
+				// API key view will handle the submission
+			}}
+		/>
 	) : showWelcome ? (
 		<WelcomeView />
 	) : (

--- a/webview-ui/src/components/welcome/AnthropicApiKeyView.tsx
+++ b/webview-ui/src/components/welcome/AnthropicApiKeyView.tsx
@@ -9,18 +9,18 @@ import { useSelectedModel } from "@src/components/ui/hooks/useSelectedModel"
 import type { ProviderName, ProviderSettings } from "@roo-code/types"
 import {
 	Anthropic,
-	Chutes,
 	ClaudeCode,
 	DeepSeek,
 	Gemini,
-	Glama,
 	Groq,
-	Mistral,
 	OpenAI,
 	OpenRouter,
-	Requesty,
-	Unbound,
 	XAI,
+	Ollama,
+	LMStudio,
+	Bedrock,
+	Vertex,
+	OpenAICompatible,
 } from "@src/components/settings/providers"
 
 interface AnthropicApiKeyViewProps {
@@ -38,21 +38,22 @@ const API_KEY_PROVIDERS = [
 	"deepseek",
 	"xai",
 	"groq",
-	"mistral",
-	"glama",
-	"chutes",
-	"requesty",
-	"unbound",
+	"ollama",
+	"lmstudio",
+	"bedrock",
+	"vertex",
+	"openai",
+	"openai-compatible",
 ] as const
 
 const AnthropicApiKeyView = ({ username, onComplete }: AnthropicApiKeyViewProps) => {
 	const { organizationAllowList, uriScheme } = useExtensionState()
 	const [apiConfiguration, setApiConfiguration] = useState<ProviderSettings>({
-		apiProvider: "anthropic",
+		apiProvider: "openrouter",
 	})
 	const [loading, setLoading] = useState(false)
 
-	const selectedProvider = apiConfiguration.apiProvider || "anthropic"
+	const selectedProvider = apiConfiguration.apiProvider || "openrouter"
 
 	const setApiConfigurationField = useCallback(
 		<K extends keyof ProviderSettings>(field: K, value: ProviderSettings[K]) => {
@@ -198,49 +199,39 @@ const AnthropicApiKeyView = ({ username, onComplete }: AnthropicApiKeyViewProps)
 						<Groq apiConfiguration={apiConfiguration} setApiConfigurationField={setApiConfigurationField} />
 					)}
 
-					{selectedProvider === "mistral" && (
-						<Mistral
+					{selectedProvider === "ollama" && (
+						<Ollama
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
 						/>
 					)}
 
-					{selectedProvider === "glama" && (
-						<Glama
+					{selectedProvider === "lmstudio" && (
+						<LMStudio
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
-							routerModels={undefined as any}
-							uriScheme={uriScheme}
+						/>
+					)}
+
+					{selectedProvider === "bedrock" && (
+						<Bedrock
+							apiConfiguration={apiConfiguration}
+							setApiConfigurationField={setApiConfigurationField}
+						/>
+					)}
+
+					{selectedProvider === "vertex" && (
+						<Vertex
+							apiConfiguration={apiConfiguration}
+							setApiConfigurationField={setApiConfigurationField}
+						/>
+					)}
+
+					{selectedProvider === "openai" && (
+						<OpenAICompatible
+							apiConfiguration={apiConfiguration}
+							setApiConfigurationField={setApiConfigurationField}
 							organizationAllowList={organizationAllowList}
-							modelValidationError={undefined}
-						/>
-					)}
-
-					{selectedProvider === "chutes" && (
-						<Chutes
-							apiConfiguration={apiConfiguration}
-							setApiConfigurationField={setApiConfigurationField}
-						/>
-					)}
-
-					{selectedProvider === "requesty" && (
-						<Requesty
-							apiConfiguration={apiConfiguration}
-							setApiConfigurationField={setApiConfigurationField}
-							routerModels={undefined as any}
-							refetchRouterModels={() => {}}
-							organizationAllowList={organizationAllowList}
-							modelValidationError={undefined}
-						/>
-					)}
-
-					{selectedProvider === "unbound" && (
-						<Unbound
-							apiConfiguration={apiConfiguration}
-							setApiConfigurationField={setApiConfigurationField}
-							routerModels={undefined as any}
-							organizationAllowList={organizationAllowList}
-							modelValidationError={undefined}
 						/>
 					)}
 				</div>

--- a/webview-ui/src/components/welcome/AnthropicApiKeyView.tsx
+++ b/webview-ui/src/components/welcome/AnthropicApiKeyView.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useMemo, useCallback } from "react"
 import { vscode } from "../../utils/vscode"
 import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
-import { SearchableSelect } from "@src/components/ui"
-import { PROVIDERS } from "@src/components/settings/constants"
-import { filterProviders } from "@src/components/settings/utils/organizationFilters"
+import { SearchableSelect, Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@src/components/ui"
+import { PROVIDERS, MODELS_BY_PROVIDER } from "@src/components/settings/constants"
+import { filterProviders, filterModels } from "@src/components/settings/utils/organizationFilters"
 import { useExtensionState } from "@src/context/ExtensionStateContext"
 import { useSelectedModel } from "@src/components/ui/hooks/useSelectedModel"
+import { useRouterModels } from "@src/components/ui/hooks/useRouterModels"
 import type { ProviderName, ProviderSettings } from "@roo-code/types"
 import {
 	Anthropic,
@@ -54,6 +55,7 @@ const AnthropicApiKeyView = ({ username, onComplete }: AnthropicApiKeyViewProps)
 	const [loading, setLoading] = useState(false)
 
 	const selectedProvider = apiConfiguration.apiProvider || "openrouter"
+	const { data: routerModels } = useRouterModels()
 
 	const setApiConfigurationField = useCallback(
 		<K extends keyof ProviderSettings>(field: K, value: ProviderSettings[K]) => {
@@ -75,6 +77,20 @@ const AnthropicApiKeyView = ({ username, onComplete }: AnthropicApiKeyViewProps)
 			label,
 		}))
 	}, [organizationAllowList])
+
+	// Get available models for the selected provider
+	const selectedProviderModels = useMemo(() => {
+		const models = MODELS_BY_PROVIDER[selectedProvider]
+		if (!models) return []
+
+		const filteredModels = filterModels(models, selectedProvider, organizationAllowList)
+		if (!filteredModels) return []
+
+		return Object.entries(filteredModels).map(([id, model]) => ({
+			value: id,
+			label: (model as any).name || id,
+		}))
+	}, [selectedProvider, organizationAllowList])
 
 	const handleSubmit = async () => {
 		setLoading(true)
@@ -166,9 +182,7 @@ const AnthropicApiKeyView = ({ username, onComplete }: AnthropicApiKeyViewProps)
 						<OpenRouter
 							apiConfiguration={apiConfiguration}
 							setApiConfigurationField={setApiConfigurationField}
-							routerModels={
-								undefined as any
-							} /* Will be fetched on demand, not needed for initial setup */
+							routerModels={routerModels}
 							selectedModelId={selectedModelId}
 							uriScheme={uriScheme}
 							fromWelcomeView={true}
@@ -235,6 +249,37 @@ const AnthropicApiKeyView = ({ username, onComplete }: AnthropicApiKeyViewProps)
 						/>
 					)}
 				</div>
+
+				{/* Model selection dropdown for providers with predefined models */}
+				{selectedProviderModels.length > 0 && (
+					<div style={{ marginTop: "12px" }}>
+						<label
+							style={{
+								display: "block",
+								fontWeight: "500",
+								marginBottom: "8px",
+								fontSize: "14px",
+							}}>
+							Model
+						</label>
+						<Select
+							value={selectedModelId || ""}
+							onValueChange={(value) => {
+								setApiConfigurationField("apiModelId", value)
+							}}>
+							<SelectTrigger className="w-full">
+								<SelectValue placeholder="Select a model" />
+							</SelectTrigger>
+							<SelectContent>
+								{selectedProviderModels.map((option) => (
+									<SelectItem key={option.value} value={option.value}>
+										{option.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				)}
 
 				{/* Button in content flow */}
 				<VSCodeButton onClick={handleSubmit} disabled={loading} style={{ width: "100%", marginTop: "16px" }}>

--- a/webview-ui/src/components/welcome/AnthropicApiKeyView.tsx
+++ b/webview-ui/src/components/welcome/AnthropicApiKeyView.tsx
@@ -1,0 +1,257 @@
+import React, { useState, useMemo, useCallback } from "react"
+import { vscode } from "../../utils/vscode"
+import { VSCodeButton } from "@vscode/webview-ui-toolkit/react"
+import { SearchableSelect } from "@src/components/ui"
+import { PROVIDERS } from "@src/components/settings/constants"
+import { filterProviders } from "@src/components/settings/utils/organizationFilters"
+import { useExtensionState } from "@src/context/ExtensionStateContext"
+import { useSelectedModel } from "@src/components/ui/hooks/useSelectedModel"
+import type { ProviderName, ProviderSettings } from "@roo-code/types"
+import {
+	Anthropic,
+	Chutes,
+	ClaudeCode,
+	DeepSeek,
+	Gemini,
+	Glama,
+	Groq,
+	Mistral,
+	OpenAI,
+	OpenRouter,
+	Requesty,
+	Unbound,
+	XAI,
+} from "@src/components/settings/providers"
+
+interface AnthropicApiKeyViewProps {
+	username?: string
+	onComplete: () => void
+}
+
+// Only include providers that require API keys for initial setup
+const API_KEY_PROVIDERS = [
+	"anthropic",
+	"claude-code",
+	"openai-native",
+	"openrouter",
+	"gemini",
+	"deepseek",
+	"xai",
+	"groq",
+	"mistral",
+	"glama",
+	"chutes",
+	"requesty",
+	"unbound",
+] as const
+
+const AnthropicApiKeyView = ({ username, onComplete }: AnthropicApiKeyViewProps) => {
+	const { organizationAllowList, uriScheme } = useExtensionState()
+	const [apiConfiguration, setApiConfiguration] = useState<ProviderSettings>({
+		apiProvider: "anthropic",
+	})
+	const [loading, setLoading] = useState(false)
+
+	const selectedProvider = apiConfiguration.apiProvider || "anthropic"
+
+	const setApiConfigurationField = useCallback(
+		<K extends keyof ProviderSettings>(field: K, value: ProviderSettings[K]) => {
+			setApiConfiguration((prev) => ({
+				...prev,
+				[field]: value,
+			}))
+		},
+		[],
+	)
+
+	const { provider: _provider, id: selectedModelId } = useSelectedModel(apiConfiguration)
+
+	// Filter providers to only show those that require API keys
+	const providerOptions = useMemo(() => {
+		const apiKeyProviders = PROVIDERS.filter((p) => API_KEY_PROVIDERS.includes(p.value as any))
+		return filterProviders(apiKeyProviders, organizationAllowList).map(({ value, label }) => ({
+			value,
+			label,
+		}))
+	}, [organizationAllowList])
+
+	const handleSubmit = async () => {
+		setLoading(true)
+		try {
+			// Send the complete API configuration to the extension
+			vscode.postMessage({
+				type: "anthropicApiKeySubmitted",
+				payload: {
+					apiConfiguration,
+					username,
+				},
+			})
+			onComplete()
+		} catch (_err) {
+			setLoading(false)
+		}
+	}
+
+	return (
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+				height: "100vh",
+				backgroundColor: "var(--vscode-editor-background)",
+				color: "var(--vscode-editor-foreground)",
+			}}>
+			{/* Scrollable content area */}
+			<div
+				style={{
+					flex: 1,
+					overflowY: "auto",
+					padding: "40px",
+					maxWidth: "600px",
+					margin: "0 auto",
+					width: "100%",
+				}}>
+				<h2 style={{ marginTop: 0 }}>Welcome{username ? `, ${username}` : ""}!</h2>
+				<h3>Choose Your AI Provider</h3>
+				<p>Select your preferred AI provider and configure your credentials to get started with SyntX.</p>
+
+				<div style={{ marginBottom: "24px", marginTop: "20px" }}>
+					<label
+						style={{
+							display: "block",
+							fontWeight: "500",
+							marginBottom: "8px",
+							fontSize: "14px",
+						}}>
+						Provider
+					</label>
+					<SearchableSelect
+						value={selectedProvider}
+						onValueChange={(value) => {
+							setApiConfigurationField("apiProvider", value as ProviderName)
+						}}
+						options={providerOptions}
+						placeholder="Select a provider"
+						searchPlaceholder="Search providers..."
+						emptyMessage="No providers found"
+						className="w-full"
+					/>
+				</div>
+
+				{/* Provider-specific configuration */}
+				<div style={{ marginBottom: "32px", display: "flex", flexDirection: "column", gap: "12px" }}>
+					{selectedProvider === "anthropic" && (
+						<Anthropic
+							apiConfiguration={apiConfiguration}
+							setApiConfigurationField={setApiConfigurationField}
+						/>
+					)}
+
+					{selectedProvider === "claude-code" && (
+						<ClaudeCode
+							apiConfiguration={apiConfiguration}
+							setApiConfigurationField={setApiConfigurationField}
+						/>
+					)}
+
+					{selectedProvider === "openai-native" && (
+						<OpenAI
+							apiConfiguration={apiConfiguration}
+							setApiConfigurationField={setApiConfigurationField}
+						/>
+					)}
+
+					{selectedProvider === "openrouter" && (
+						<OpenRouter
+							apiConfiguration={apiConfiguration}
+							setApiConfigurationField={setApiConfigurationField}
+							routerModels={
+								undefined as any
+							} /* Will be fetched on demand, not needed for initial setup */
+							selectedModelId={selectedModelId}
+							uriScheme={uriScheme}
+							fromWelcomeView={true}
+							organizationAllowList={organizationAllowList}
+							modelValidationError={undefined}
+						/>
+					)}
+
+					{selectedProvider === "gemini" && (
+						<Gemini
+							apiConfiguration={apiConfiguration}
+							setApiConfigurationField={setApiConfigurationField}
+						/>
+					)}
+
+					{selectedProvider === "deepseek" && (
+						<DeepSeek
+							apiConfiguration={apiConfiguration}
+							setApiConfigurationField={setApiConfigurationField}
+						/>
+					)}
+
+					{selectedProvider === "xai" && (
+						<XAI apiConfiguration={apiConfiguration} setApiConfigurationField={setApiConfigurationField} />
+					)}
+
+					{selectedProvider === "groq" && (
+						<Groq apiConfiguration={apiConfiguration} setApiConfigurationField={setApiConfigurationField} />
+					)}
+
+					{selectedProvider === "mistral" && (
+						<Mistral
+							apiConfiguration={apiConfiguration}
+							setApiConfigurationField={setApiConfigurationField}
+						/>
+					)}
+
+					{selectedProvider === "glama" && (
+						<Glama
+							apiConfiguration={apiConfiguration}
+							setApiConfigurationField={setApiConfigurationField}
+							routerModels={undefined as any}
+							uriScheme={uriScheme}
+							organizationAllowList={organizationAllowList}
+							modelValidationError={undefined}
+						/>
+					)}
+
+					{selectedProvider === "chutes" && (
+						<Chutes
+							apiConfiguration={apiConfiguration}
+							setApiConfigurationField={setApiConfigurationField}
+						/>
+					)}
+
+					{selectedProvider === "requesty" && (
+						<Requesty
+							apiConfiguration={apiConfiguration}
+							setApiConfigurationField={setApiConfigurationField}
+							routerModels={undefined as any}
+							refetchRouterModels={() => {}}
+							organizationAllowList={organizationAllowList}
+							modelValidationError={undefined}
+						/>
+					)}
+
+					{selectedProvider === "unbound" && (
+						<Unbound
+							apiConfiguration={apiConfiguration}
+							setApiConfigurationField={setApiConfigurationField}
+							routerModels={undefined as any}
+							organizationAllowList={organizationAllowList}
+							modelValidationError={undefined}
+						/>
+					)}
+				</div>
+
+				{/* Button in content flow */}
+				<VSCodeButton onClick={handleSubmit} disabled={loading} style={{ width: "100%", marginTop: "16px" }}>
+					{loading ? "Saving..." : "Continue"}
+				</VSCodeButton>
+			</div>
+		</div>
+	)
+}
+
+export default AnthropicApiKeyView

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -25,6 +25,7 @@ import { convertTextMateToHljs } from "@src/utils/textMateToHljs"
 
 export interface ExtensionStateContextType extends ExtensionState {
 	showModes?: boolean
+	showAnthropicApiKeyScreen?: boolean
 	historyPreviewCollapsed?: boolean // Add the new state property
 	didHydrateState: boolean
 	showWelcome: boolean
@@ -224,6 +225,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		websiteUsername: undefined,
 		syntxApiKey: undefined,
 		websiteNotAuthenticated: true, // Default to not authenticated
+		showAnthropicApiKeyScreen: false,
 		organizationAllowList: ORGANIZATION_ALLOW_ALL,
 		autoCondenseContext: true,
 		autoCondenseContextPercent: 100,
@@ -327,6 +329,18 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 					})
 					break
 				}
+				case "requestAnthropicApiKey": {
+					// Show the API key collection screen
+					if (message.text) {
+						const { username } = JSON.parse(message.text)
+						setState((prevState) => ({
+							...prevState,
+							showAnthropicApiKeyScreen: true,
+							websiteUsername: username,
+						}))
+					}
+					break
+				}
 				case "mcpServers": {
 					setMcpServers(message.mcpServers ?? [])
 					break
@@ -361,6 +375,8 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 							websiteNotAuthenticated: !authenticated,
 							websiteUsername: username,
 							syntxApiKey: apiKey,
+							// Hide the API key screen after successful auth
+							showAnthropicApiKeyScreen: false,
 						}))
 					}
 					break
@@ -401,6 +417,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		websiteUsername: state.websiteUsername,
 		syntxApiKey: state.syntxApiKey,
 		websiteNotAuthenticated: state.websiteNotAuthenticated ?? true,
+		showAnthropicApiKeyScreen: state.showAnthropicApiKeyScreen ?? false,
 		marketplaceItems,
 		marketplaceInstalledMetadata,
 		profileThresholds: state.profileThresholds ?? {},


### PR DESCRIPTION
This pull request introduces provider configuration at the startup screen, allowing users to select and configure their AI provider and credentials during initial setup. The default provider is changed to `openrouter`, and a new onboarding flow is added for collecting API keys and provider preferences. The changes span backend state management, UI updates, and message handling between the extension and webview.

**Provider onboarding and configuration:**

* Added a new onboarding flow that displays an API key and provider selection screen (`AnthropicApiKeyView`) after website authentication, enabling users to choose and configure their preferred AI provider before using the extension. 
* Changed the default provider from `syntx` to `openrouter` in `ProviderSettingsManager` and after website login, aligning the extension's default configuration with the new onboarding flow. 

**State and message handling enhancements:**

* Added new message types (`requestAnthropicApiKey`, `anthropicApiKeySubmitted`) and state properties (`showAnthropicApiKeyScreen`) to coordinate the onboarding flow and API key submission between the extension backend and webview UI. 
**General updates:**

* Updated the extension version to `2.5.0` and added a changelog entry for provider configuration at the startup screen. 
* Integrated the new onboarding screen into the main app flow, ensuring it's rendered when required. 

These changes collectively improve the user experience by making provider selection and API key configuration a seamless part of the onboarding process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider configuration screen now available at startup to select and configure your preferred AI provider.
  * Enhanced authentication workflow with streamlined API key submission interface.
  * Updated default provider selection for improved service delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->